### PR TITLE
do not assume a default ordering by primary keys on relations

### DIFF
--- a/formalchemy/fields.py
+++ b/formalchemy/fields.py
@@ -1928,11 +1928,12 @@ class AttributeField(AbstractField):
             else:
                 self.render_opts['options'] = [self._null_option]
             # todo 2.0 this does not handle primaryjoin (/secondaryjoin) alternate join conditions
-            fk_cls = self.relation_type()
-            order_by = self._property.order_by or list(class_mapper(fk_cls).primary_key)
-            if order_by and not isinstance(order_by, list):
-                order_by = [order_by]
-            q = self.query(fk_cls).order_by(*order_by)
+            q = self.query(self.relation_type())
+            order_by = self._property.order_by
+            if order_by:
+                if not isinstance(order_by, list):
+                    order_by = [order_by]
+                q = q.order_by(*order_by)
             self.render_opts['options'] += _query_options(q)
             logger.debug('options for %s are %s' % (self.name, self.render_opts['options']))
         if self.is_collection and isinstance(self.renderer, self.parent.default_renderers['dropdown']):


### PR DESCRIPTION
so that it does not override default order_by which may have been defined in
the sqlalchemy mapper:
http://docs.sqlalchemy.org/en/rel_0_7/orm/mapper_config.html#sqlalchemy.orm.mapper
