### PR TITLE
configure_mappers is only available in sqlalchemy v0.7+

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -26,7 +26,7 @@ eggs =
     Mako>=0.2.4
     genshi
     pysqlite>=2.5.5
-    SQLAlchemy<0.7
+    SQLAlchemy>=0.7
     RDFAlchemy
     FormAlchemy
     BeautifulSoup


### PR DESCRIPTION
see: http://www.sqlalchemy.org/changelog/CHANGES_0_7b1
