### PR TITLE
forms.py: do not use "eval"

### DIFF
--- a/formalchemy/forms.py
+++ b/formalchemy/forms.py
@@ -752,7 +752,8 @@ class FieldSet(DefaultRenderers):
         include = list(include)
         exclude = list(exclude)
         options = list(options)
-        for L in (include, exclude, options):
+        for iterable in ('include', 'exclude', 'options'):
+            L = locals()[iterable]
             for field in L:
                 if not isinstance(field, fields.AbstractField):
                     raise TypeError('non-AbstractField object `%s` found in `%s`' % (field, iterable))


### PR DESCRIPTION
The 'eval' used here is useless. The goal is to copy any enumerators
into a list and then use that list for further processing, so let's just do
that.
