### PR TITLE
Removed a couple of grammatically-wrong apostrophes

### DIFF
--- a/docs/ext/pylons.txt
+++ b/docs/ext/pylons.txt
@@ -121,7 +121,7 @@ RESTful controller
 
 This module provide a RESTful controller for formalchemy's FieldSets.
 
-You can use your fieldset as a REST resource. And yes, it's also work with JSON.
+You can use your fieldset as a REST resource. And yes, it also works with JSON.
 
 Usage
 ------

--- a/docs/forms.txt
+++ b/docs/forms.txt
@@ -28,8 +28,8 @@ Binding
 
 Binding occurs at first on :class:`FieldSet` object creation.
 
-The :class:`~formalchemy.forms.FieldSet` object constructor takes it's
-parameters and calls it's base class's constructor.
+The :class:`~formalchemy.forms.FieldSet` object constructor takes i's
+parameters and calls its base class's constructor.
 
 
 Fields

--- a/formalchemy/fields.py
+++ b/formalchemy/fields.py
@@ -74,7 +74,7 @@ del _NoDefault
 def deserialize_once(func):
     """Simple deserialization caching decorator.
 
-    To be used on a Renderer object's `deserialize` function, to cache it's
+    To be used on a Renderer object's `deserialize` function, to cache its
     result while it's being called once for ``validate()`` and another time
     when doing ``sync()``.
     """
@@ -312,11 +312,11 @@ class FieldRenderer(object):
 
         .. note::
          Note that this function will be called *twice*, once when
-         the fieldset is `.validate()`'d -- with it's value only tested,
-         and a second time when the fieldset is `.sync()`'d -- and it's
+         the fieldset is `.validate()`'d -- with its value only tested,
+         and a second time when the fieldset is `.sync()`'d -- and its
          value assigned to the model. Also note that deserialize() can
          also raise a ValidationError() exception if it finds some
-         errors converting it's values.
+         errors converting its values.
 
         If calling this function twice poses a problem to your logic, for
         example, if you have heavy database queries, or temporary objects

--- a/formalchemy/forms.py
+++ b/formalchemy/forms.py
@@ -184,7 +184,7 @@ class FieldSet(DefaultRenderers):
 
         - `request=None`:
               WebOb-like object that can be taken in place of `data`.
-              FormAlchemy will make sure it's a POST, and use it's 'POST'
+              FormAlchemy will make sure it's a POST, and use its 'POST'
               attribute as the data.  Also, the request object will be
               available to renderers as the `.request` attribute.
 

--- a/formalchemy/tests/test_tables.py
+++ b/formalchemy/tests/test_tables.py
@@ -118,7 +118,7 @@ def test_extra_field():
     ...
     Exception: instances must be an iterable, not <class 'formalchemy.tests.User'>
 
-    Simulate creating a grid in a different thread than it's used in:
+    Simulate creating a grid in a different thread than the one it's used in:
     >>> _Session = sessionmaker(bind=engine)
     >>> _old_session = _Session()
     >>> assert _old_session != object_session(john)


### PR DESCRIPTION
"it's" is a shortcut for "it is" and not a possessive.
