### PR TITLE
Do not overwrite read-only values!

### DIFF
--- a/formalchemy/forms.py
+++ b/formalchemy/forms.py
@@ -579,7 +579,8 @@ class FieldSet(DefaultRenderers):
         if self.data is None:
             raise Exception("No data bound; cannot sync")
         for field in self.render_fields.itervalues():
-            field.sync()
+            if not field.is_readonly():
+                field.sync(force=force)
         if self.session:
             self.session.add(self.model)
 


### PR DESCRIPTION
This may be a security hole, but the more immediate effect of this problem
is that it's not possible to have a fieldset which selectively displays
some fields as read-only -- on submission, the missing values will be
erased from the model. Ouch.
