### PR TITLE
fix for change in webhelpers2 (fixes #62)

### DIFF
--- a/formalchemy/helpers.py
+++ b/formalchemy/helpers.py
@@ -173,7 +173,7 @@ def select(name, selected, select_options, **attrs):
     """
     if 'options' in attrs:
         del attrs['options']
-    select_options = _sanitize_select_options(select_options)
+    select_options = (tags.Option(*reversed(o)) for o in _sanitize_select_options(select_options))
     _update_fa(attrs, name)
     if six.PY3 and isinstance(selected,map): # this test fails with py2
         selected = tuple(selected)


### PR DESCRIPTION
This fixes #62, admittedly with brute force.

As noted in issue 62, webhelpers2 does not permit options to be tuples anymore; from http://webhelpers2.readthedocs.org/en/latest/modules/html/tags.html :
“[Late change in 2.0rc3] The options argument to select no longer accepts lists of lists, lists of tuples, or other complex data structures. You can no longer pass [(myvalue, mylabel)] or [(optgroup_label, options)]; these now raise TypeError. Instead you should explicitly build up an Options instance and pass it. This restriction was made for simplicity, reliability, and maintainability.”