### PR TITLE
Change form ignore attributes to retain synonyms

### DIFF
--- a/formalchemy/forms.py
+++ b/formalchemy/forms.py
@@ -287,9 +287,9 @@ class FieldSet(DefaultRenderers):
                 ignore_keys = set()
                 for p in class_mapper(cls).iterate_properties:
                     if isinstance(p, SynonymProperty):
-                        #ignore_keys.add(p.name)
+                        ignore_keys.add(p.name)
                         # Can't ignore the original, this hides synonymized relationships when the ID it points to is not also synonymed
-                        ignore_keys.add(p.key)
+                        # ignore_keys.add(p.key)
                     elif hasattr(p, '_is_polymorphic_discriminator') and p._is_polymorphic_discriminator:
                         ignore_keys.add(p.key)
                     elif isinstance(p, CompositeProperty):
@@ -300,7 +300,9 @@ class FieldSet(DefaultRenderers):
                 attrs = []
                 for p in class_mapper(cls).iterate_properties:
                     attr = _get_attribute(cls, p)
-                    if attr.property.key not in ignore_keys and p.key not in ignore_keys and not isinstance(attr.impl, DynamicAttributeImpl):
+                    if ((isinstance(p, SynonymProperty) or (attr.property.key not in ignore_keys
+                        and p.key not in ignore_keys))
+                        and not isinstance(attr.impl, DynamicAttributeImpl)):
                         attrs.append(attr)
                 # sort relations last before storing in the OrderedDict
                 L = [fields.AttributeField(attr, self) for attr in attrs]


### PR DESCRIPTION
In older versions of formalchemy, synonyms worked. This commit returns
a small amount of functionality that seems to have been dropped at some
point. The original 'ignore_keys' stanza had a special call out for
synonym properties to include. This has the effect of hiding the
properties that are the original target of the synonym but exposing
the synonym property.

The code was mostly cribbed from a version that I knew to work with
synonym properties.

https://github.com/FormAlchemy/formalchemy/blob/1f34e86cd75075732259473086c50de1eb62ebfa/formalchemy/forms.py#L312

With these changes:

    >>> from formalchemy import FieldSet
    >>> fs = FieldSet(User)
    >>> fs.password
    AttributeField(password)
    >>> print fs.password.render()
    <input id="User--password" maxlength="28" name="User--password" type="text" />
    >>> # the synonym is for a property named _password
    >>> fs._password
    Traceback (most recent call last):
      File "<console>", line 1, in <module>
      File "/usr/share/ps/formalchemy/formalchemy/forms.py", line 801, in __getattr__
        raise AttributeError(attrname)
    AttributeError: _password