### PR TITLE
Removed the six import from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ import xml.sax.saxutils
 from os.path import join
 import sys
 import os
-from six import text_type
 
 def get_version(fname='formalchemy/__init__.py'):
     with open(fname) as f:


### PR DESCRIPTION
The six library isn't available during the installation process, so this line was preventing FormAlchemy distributions made from the master branch from being installable via pip. The import wasn't being used, either, so I'm really not sure why it was there in the first place.

This PR is related to #71.